### PR TITLE
Make IDs consistent with other converters

### DIFF
--- a/lightstep/lightstep.go
+++ b/lightstep/lightstep.go
@@ -104,13 +104,11 @@ func lightStepSpan(data *export.SpanData) *ls.RawSpan {
 }
 
 func convertTraceID(id core.TraceID) uint64 {
-	first := binary.LittleEndian.Uint64(id[:8])
-	second := binary.LittleEndian.Uint64(id[8:])
-	return first ^ second
+	return binary.BigEndian.Uint64(id[:8])
 }
 
 func convertSpanID(id core.SpanID) uint64 {
-	return binary.LittleEndian.Uint64(id[:])
+	return binary.BigEndian.Uint64(id[:])
 }
 
 func toLogRecords(input []export.Event) []opentracing.LogRecord {


### PR DESCRIPTION
Other implementations (e.g., for B3) convert IDs using big-endian
instead of little-endian, and use the high bytes for the trace ID.