### PR TITLE
Add plain text export option for developer satellite support

### DIFF
--- a/lightstep/lightstep.go
+++ b/lightstep/lightstep.go
@@ -45,6 +45,13 @@ func WithServiceName(serviceName string) Option {
 	}
 }
 
+
+func WithPlainText(pt bool) Option {
+	return func(c *config) {
+		c.options.Collector.Plaintext = pt
+	}
+}
+
 type config struct {
 	options ls.Options
 }


### PR DESCRIPTION
I needed this to get local https://docs.lightstep.com/docs/use-developer-mode working as by default it uses http without TLS on port 8360