### PR TITLE
Test exported resources and events

### DIFF
--- a/lightstep/lightstep.go
+++ b/lightstep/lightstep.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/api/kv"
 	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/opentracing/opentracing-go"
 
@@ -145,7 +146,7 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 		ls.SetSpanID(convertSpanID(data.SpanContext.SpanID)),
 		ls.SetParentSpanID(convertSpanID(data.ParentSpanID)),
 		opentracing.StartTime(data.StartTime),
-		opentracing.Tags(toTags(data.Attributes)),
+		opentracing.Tags(toTags(data.Attributes, data.Resource)),
 	).FinishWithOptions(
 		opentracing.FinishOptions{
 			FinishTime: data.EndTime,
@@ -174,12 +175,14 @@ func lightStepSpan(data *trace.SpanData) *ls.RawSpan {
 		TraceID: convertTraceID(data.SpanContext.TraceID),
 		SpanID:  convertSpanID(data.SpanContext.SpanID),
 	}
+	tags := toTags(data.Attributes, data.Resource)
+
 	lsSpan := &ls.RawSpan{
 		Context:      spanContext,
 		ParentSpanID: convertSpanID(data.ParentSpanID),
 		Operation:    data.Name,
 		Start:        data.StartTime,
-		Tags:         toTags(data.Attributes),
+		Tags:         tags,
 		Logs:         toLogRecords(data.MessageEvents),
 	}
 	lsSpan.Duration = data.EndTime.Sub(data.StartTime)
@@ -195,6 +198,9 @@ func convertSpanID(id apitrace.SpanID) uint64 {
 }
 
 func toLogRecords(input []trace.Event) []opentracing.LogRecord {
+	if len(input) == 0 {
+		return nil
+	}
 	output := make([]opentracing.LogRecord, 0, len(input))
 	for _, l := range input {
 		output = append(output, toLogRecord(l))
@@ -202,8 +208,12 @@ func toLogRecords(input []trace.Event) []opentracing.LogRecord {
 	return output
 }
 
-func toTags(input []kv.KeyValue) map[string]interface{} {
+func toTags(input []kv.KeyValue, resource *resource.Resource) map[string]interface{} {
 	output := make(map[string]interface{})
+	for iter := resource.Iter(); iter.Next(); {
+		kv := iter.Label()
+		output[string(kv.Key)] = kv.Value.Emit()
+	}
 	for _, value := range input {
 		output[string(value.Key)] = value.Value.AsInterface()
 	}
@@ -213,12 +223,13 @@ func toTags(input []kv.KeyValue) map[string]interface{} {
 func toLogRecord(ev trace.Event) opentracing.LogRecord {
 	return opentracing.LogRecord{
 		Timestamp: ev.Time,
-		Fields:    toFields(ev.Attributes),
+		Fields:    toFields(ev.Name, ev.Attributes),
 	}
 }
 
-func toFields(input []kv.KeyValue) []log.Field {
-	output := make([]log.Field, 0, len(input))
+func toFields(name string, input []kv.KeyValue) []log.Field {
+	output := make([]log.Field, 0, len(input)+1)
+	output = append(output, log.String("name", name))
 	for _, value := range input {
 		output = append(output, log.Object(string(value.Key), value.Value.AsInterface()))
 	}

--- a/lightstep/lightstep_test.go
+++ b/lightstep/lightstep_test.go
@@ -5,14 +5,19 @@ import (
 	"time"
 
 	ls "github.com/lightstep/lightstep-tracer-go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/api/kv"
 	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 func TestExport(t *testing.T) {
 	assert := assert.New(t)
 	now := time.Now().Round(time.Microsecond)
+
 	traceID, _ := apitrace.IDFromHex("0102030405060708090a0b0c0d0e0f10")
 	spanID, _ := apitrace.SpanIDFromHex("0102030405060708")
 
@@ -34,6 +39,13 @@ func TestExport(t *testing.T) {
 				Name:      "/test",
 				StartTime: now,
 				EndTime:   now,
+				Resource: resource.New(
+					kv.String("R1", "V1"),
+				),
+				Attributes: []kv.KeyValue{
+					kv.String("A", "B"),
+					kv.String("C", "D"),
+				},
 			},
 			want: &ls.RawSpan{
 				Context: ls.SpanContext{
@@ -43,16 +55,63 @@ func TestExport(t *testing.T) {
 				Operation: "/test",
 				Start:     now,
 				Duration:  0,
+				Tags: opentracing.Tags{
+					"A":  "B",
+					"C":  "D",
+					"R1": "V1",
+				},
+			},
+		},
+		{
+			name: "with events",
+			data: &trace.SpanData{
+				SpanContext: apitrace.SpanContext{
+					TraceID: traceID,
+					SpanID:  spanID,
+				},
+				Name:      "/test",
+				StartTime: now,
+				EndTime:   now,
+				MessageEvents: []trace.Event{
+					trace.Event{
+						Name: "myevent",
+						Attributes: []kv.KeyValue{
+							kv.String("A", "B"),
+						},
+						Time: now,
+					},
+				},
+				Resource: resource.New(
+					kv.String("R1", "V1"),
+				),
+			},
+			want: &ls.RawSpan{
+				Context: ls.SpanContext{
+					TraceID: expectedTraceID,
+					SpanID:  expectedSpanID,
+				},
+				Operation: "/test",
+				Start:     now,
+				Duration:  0,
+				Tags: opentracing.Tags{
+					"R1": "V1",
+				},
+				Logs: []opentracing.LogRecord{
+					opentracing.LogRecord{
+						Timestamp: now,
+						Fields: []log.Field{
+							log.String("name", "myevent"),
+							log.Object("A", "B"),
+						},
+					},
+				},
 			},
 		},
 	}
 
 	for _, test := range tests {
 		lsSpan := lightStepSpan(test.data)
-		assert.EqualValues(test.want.Operation, lsSpan.Operation)
-		assert.EqualValues(test.want.Context.SpanID, lsSpan.Context.SpanID)
-		assert.EqualValues(test.want.Context.TraceID, lsSpan.Context.TraceID)
-		assert.EqualValues(0, lsSpan.ParentSpanID)
+		assert.EqualValues(test.want, lsSpan)
 	}
 }
 

--- a/lightstep/translator.go
+++ b/lightstep/translator.go
@@ -4,16 +4,15 @@ package lightstep
 
 import (
 	"errors"
-	"go.opentelemetry.io/otel/sdk/resource"
 	"time"
+
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"go.opentelemetry.io/otel/api/kv"
 	apitrace "go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/sdk/export/trace"
-
-	"go.opentelemetry.io/otel/api/key"
 )
 
 // timestampToTime creates a Go time.Time value from a Google protobuf Timestamp.
@@ -96,6 +95,10 @@ func createOTelEvents(spanEvents *tracepb.Span_TimeEvents) []trace.Event {
 		}
 	}
 
+	if annotations == 0 {
+		return nil
+	}
+
 	events := make([]trace.Event, annotations)
 
 	for i, event := range spanEvents.TimeEvent {
@@ -166,10 +169,10 @@ func spanResource(span *tracepb.Span) *resource.Resource {
 	if span.Resource == nil {
 		return nil
 	}
-	attrs := make([]core.KeyValue, len(span.Resource.Labels))
+	attrs := make([]kv.KeyValue, len(span.Resource.Labels))
 	i := 0
 	for k, v := range span.Resource.Labels {
-		attrs[i] = key.String(k, v)
+		attrs[i] = kv.String(k, v)
 		i++
 	}
 	return resource.New(attrs...)


### PR DESCRIPTION
This implements and tests the direct-to-lightstep export path for resources.
This fixes and tests a bug in the conversion of events to span logs.
CC: @vikrambe 